### PR TITLE
Fix Images

### DIFF
--- a/src/main/java/io/slingr/endpoints/pdfGenerator/PdfEngine.java
+++ b/src/main/java/io/slingr/endpoints/pdfGenerator/PdfEngine.java
@@ -27,7 +27,7 @@ public class PdfEngine {
     private String footerTmpFile;
 
     private final String TMP_PATH = "/tmp";
-
+    public static boolean downloadImages;
 
     public PdfEngine(String tpl, Json settings, boolean downloadImages) throws IOException, TemplateException {
 
@@ -106,6 +106,13 @@ public class PdfEngine {
                 tpl.process(data.toMap(), sw);
 
                 template = sw.toString();
+                if (downloadImages) {
+                    Map<String, String> urlImgs = PdfGenerator.extractImageUrlsFromHtml(template);
+                    for (Map.Entry<String, String> entry : urlImgs.entrySet()) {
+                        template = template.replace(entry.getKey(), entry.getValue());
+                    }
+                    logger.info(String.format("Template [%s]", template));
+                }
 
                 File temp = File.createTempFile("pdf-header-" + Strings.randomUUIDString(), ".html");
                 FileUtils.writeStringToFile(temp, template, "UTF-8");

--- a/src/main/java/io/slingr/endpoints/pdfGenerator/PdfHeaderFooterHandler.java
+++ b/src/main/java/io/slingr/endpoints/pdfGenerator/PdfHeaderFooterHandler.java
@@ -34,6 +34,7 @@ public class PdfHeaderFooterHandler {
 
     private Map<String, String> tempFiles = new HashMap<>();
 
+    public static boolean downloadImages;
 
     public String setHeaderWithImage(InputStream report, String headerTemplate, float hHeight, float hWidth, String footerTemplate, float fHeight, float fWidth) {
 
@@ -262,8 +263,15 @@ public class PdfHeaderFooterHandler {
                 if (data != null) {
                     tpl.process(data.toMap(), sw);
                 }
-
-                return sw.toString();
+                String swString = sw.toString();
+                if (downloadImages) {
+                    Map<String, String> urlImgs = PdfGenerator.extractImageUrlsFromHtml(swString);
+                    for (Map.Entry<String, String> entry : urlImgs.entrySet()) {
+                        swString = swString.replace(entry.getKey(), entry.getValue());
+                    }
+                    logger.info(String.format("Template [%s]", swString));
+                }
+                return swString;
 
             }
         } catch (IOException | TemplateException ex) {


### PR DESCRIPTION
Solo para el registro.
Se aplico este fix al pdf-generator y pdf-service.

Basicamente se utiliza parte de la solución previamente implementada en el que se descargaban las imagenes en el pod de la integración. 
El agregado es que ya no se envia en el `<img src="` el path del archivo en el filesystem, sino que ahora se obtiene el contenido de la imagen en base64 y se injecta en la propiedad src con el siguiente formato:
`data:image/{contentType};base64 {content enconded in base64}`
Esto fuerza a que el template, el footer y el header de HTML tengan el contenido de la imagen y evita que el programa `wkhtmltopdf` tenga que descargar manualmente esas referencias (ya sea de un servicio externo como pasaba en el header y footer o desde el filesystem como pasaba con el template body).